### PR TITLE
Allow to install from PR or github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "package:upgrade": "./node_modules/.bin/ncu -u",
     "package:prod": "./node_modules/.bin/ncu -u",
     "package:dev": "./node_modules/.bin/ncu -p -u",
+    "prepare": "npm run dist",
     "asset-server": "node config/webpack/webpack.hot.assets.config",
     "publish-patch": "git add -A && npm run dist && git commit && git push -u origin 4.1 && git push --tags && npm version patch && npm publish",
     "publish-minor": "git add -A && npm run dist && git commit && git push -u origin 4.1 && git push --tags && npm version minor && npm publish",


### PR DESCRIPTION
## Changelog
### Changed

- add prepare lifecycle in package.json  script
- allow as to install phraseanet-production-client from PR or from this repository

in Phraseanet project
  - npm install alchemy-fr/Phraseanet-production-client#<PR_ID>/head
  - make install_assets

